### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   Scan-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/LanikSJ/security/code-scanning/1](https://github.com/LanikSJ/LanikSJ/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the provided steps, the workflow requires `contents: read` to check out the repository and `security-events: write` to upload the SARIF report. These permissions will be explicitly set.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
