### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   # For non-forks, we will maintain a sibling PR
   restyled:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/LanikSJ/security/code-scanning/2](https://github.com/LanikSJ/LanikSJ/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow (e.g., interacting with pull requests, checking out code, and running actions), the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating and managing pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions for specific tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
