### PR TITLE
ci: align metrics workflow with user-statistician stats

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,5 +1,5 @@
 # This workflow generates GitHub stats metrics using lowlighter/metrics.
-# Configured with dark theme and minimal output. Runs daily at 3am.
+# Configured to match the same stats as user-statistician. Runs daily at 3am.
 
 name: Metrics
 
@@ -23,5 +23,25 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           config_timezone: America/Los_Angeles
+          config_display: large
+          config_output: svg
+          filename: images/userstats.svg
+          base: header, activity, community, repositories, metadata
+          base_indepth: yes
+          repositories_forks: yes
           plugin_languages: yes
           plugin_languages_details: bytes-size, percentage
+          plugin_languages_indepth: yes
+          plugin_languages_limit: 8
+          plugin_followup: yes
+          plugin_followup_sections: repositories
+          plugin_lines: yes
+          plugin_lines_history_limit: 1
+          plugin_lines_repositories_limit: 4
+          plugin_habits: yes
+          plugin_habits_from: 200
+          plugin_habits_days: 365
+          plugin_habits_facts: yes
+          plugin_habits_charts: yes
+          plugin_stargazers: yes
+          plugin_stargazers_charts_type: classic


### PR DESCRIPTION
- Update lowlighter/metrics action configuration to produce the same statistics as the user-statistician tool.
- Added plugins for languages (in-depth, limit 8), followup, lines, habits, and stargazers.
- Changed output to SVG with large display and set filename to images/userstats.svg.
