### PR TITLE
ci: simplify metrics workflow by removing unused plugins and options

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,5 +1,5 @@
 # This workflow generates GitHub stats metrics using lowlighter/metrics.
-# Configured to match the same stats as user-statistician. Runs daily at 3am.
+# Runs daily at 3am.
 
 name: Metrics
 
@@ -23,25 +23,8 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           config_timezone: America/Los_Angeles
-          config_display: large
-          config_output: svg
           filename: images/userstats.svg
           base: header, activity, community, repositories, metadata
-          base_indepth: yes
-          repositories_forks: yes
           plugin_languages: yes
           plugin_languages_details: bytes-size, percentage
-          plugin_languages_indepth: yes
-          plugin_languages_limit: 8
           plugin_followup: yes
-          plugin_followup_sections: repositories
-          plugin_lines: yes
-          plugin_lines_history_limit: 1
-          plugin_lines_repositories_limit: 4
-          plugin_habits: yes
-          plugin_habits_from: 200
-          plugin_habits_days: 365
-          plugin_habits_facts: yes
-          plugin_habits_charts: yes
-          plugin_stargazers: yes
-          plugin_stargazers_charts_type: classic


### PR DESCRIPTION
- Remove several plugin configurations and settings from the metrics workflow that were previously used to match user-statistician stats.
- This includes display options, indepth analysis, language limits, followup sections, lines history, habits, and stargazers.
- The workflow now only generates basic metrics with languages and followup, reducing complexity and execution time.
