### PR TITLE
ci: simplify metrics workflow to only generate language stats

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,4 +1,4 @@
-# This workflow generates GitHub stats metrics using lowlighter/metrics.
+# This workflow generates GitHub language stats using lowlighter/metrics.
 # Runs daily at 3am.
 
 name: Metrics
@@ -24,7 +24,5 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           config_timezone: America/Los_Angeles
           filename: images/userstats.svg
-          base: header, activity, community, repositories, metadata
           plugin_languages: yes
           plugin_languages_details: bytes-size, percentage
-          plugin_followup: yes


### PR DESCRIPTION
- Removed base metrics (header, activity, community, repositories, metadata) and follow-up plugin to focus solely on language statistics.
- Updated workflow description accordingly.
