### PR TITLE
ci: only allow manual runs for user-statistician workflow

### DIFF
--- a/.github/workflows/user-statistician.yml
+++ b/.github/workflows/user-statistician.yml
@@ -8,14 +8,14 @@ permissions:
   contents: write
 
 on:
-  schedule:
-    - cron: "0 3 * * *"
-  push:
-    branches: [main, master]
-    paths: [".github/workflows/user-statistician.yml"]
-  pull_request:
-    branches: [main, master]
-    paths: [".github/workflows/user-statistician.yml"]
+  # schedule:
+  #   - cron: "0 3 * * *"
+  # push:
+  #   branches: [main, master]
+  #   paths: [".github/workflows/user-statistician.yml"]
+  # pull_request:
+  #   branches: [main, master]
+  #   paths: [".github/workflows/user-statistician.yml"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Comment out schedule, push, and pull_request triggers.
- Workflow now only runs when manually triggered via workflow_dispatch.
