### PR TITLE
chore: use built-in GITHUB_TOKEN in user-statistician workflow

### DIFF
--- a/.github/workflows/user-statistician.yml
+++ b/.github/workflows/user-statistician.yml
@@ -31,4 +31,4 @@ jobs:
           colors: dark
           fail-on-error: false
         env:
-          GITHUB_TOKEN: ${{secrets.PAT_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- Replace PAT_TOKEN with GITHUB_TOKEN to use the default token provided by GitHub Actions, improving security and removing the need for a custom secret.
