### PR TITLE
ci: remove fail-on-error flag from user statistician workflow

### DIFF
--- a/.github/workflows/user-statistician.yml
+++ b/.github/workflows/user-statistician.yml
@@ -29,6 +29,5 @@ jobs:
         uses: cicirello/user-statistician@36500351ea14b69e68217d4c89eb0f3f06680b17 # v1.26.3
         with:
           colors: dark
-          fail-on-error: false
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- This flag is no longer necessary and was only added for testing purposes
